### PR TITLE
Add DeletionPropagation to DeleteOptions

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -4,11 +4,12 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/wish/ctl/cmd/util/parsing"
 	"github.com/wish/ctl/pkg/client"
-	"io"
-	"strings"
 )
 
 var supportedDeleteTypes = [][]string{
@@ -67,7 +68,8 @@ func deleteCmd(c *client.Client) *cobra.Command {
 			labelColumns, _ := cmd.Flags().GetStringSlice("label-columns")
 
 			now, _ := cmd.Flags().GetBool("now")
-			deleteOptions := client.DeleteOptions{Now: now}
+			deleteChildren, _ := cmd.Flags().GetBool("delete-children")
+			deleteOptions := client.DeleteOptions{Now: now, DeletionPropagation: deleteChildren}
 
 			switch strings.ToLower(args[0]) {
 			case "pods", "pod", "po":
@@ -265,6 +267,7 @@ func deleteCmd(c *client.Client) *cobra.Command {
 
 	cmd.Flags().StringSlice("label-columns", nil, "Prints with columns that contain the value of the specified label")
 	cmd.Flags().Bool("now", false, "If true, signals the resource for immediate shutdown")
+	cmd.Flags().Bool("delete-children", true, "If true, deletes jobs' spawned resources")
 
 	return cmd
 }

--- a/pkg/client/deletejob.go
+++ b/pkg/client/deletejob.go
@@ -11,10 +11,14 @@ func (c *Client) DeleteJob(context, namespace, name string, options DeleteOption
 		return err
 	}
 
-	var deleteOptions *metav1.DeleteOptions
+	deleteOptions := &metav1.DeleteOptions{}
 	if options.Now {
 		var one int64 = 1
-		deleteOptions = &metav1.DeleteOptions{GracePeriodSeconds: &one}
+		deleteOptions.GracePeriodSeconds = &one
+	}
+	if options.DeletionPropagation {
+		bg := metav1.DeletePropagationBackground
+		deleteOptions.PropagationPolicy = &bg
 	}
 
 	return cl.BatchV1().Jobs(namespace).Delete(name, deleteOptions)

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -1,8 +1,9 @@
 package client
 
 import (
-	"github.com/wish/ctl/pkg/client/filter"
 	"regexp"
+
+	"github.com/wish/ctl/pkg/client/filter"
 )
 
 // ListOptions is used to specify filtering on list operations
@@ -40,4 +41,6 @@ type DescribeOptions struct {
 type DeleteOptions struct {
 	// When set, the resource is deleted immediately by setting GracePeriodSeconds to 0.
 	Now bool
+	// When set, the spawned resources created by a job are also deleted
+	DeleteionPropagation bool
 }

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -42,5 +42,5 @@ type DeleteOptions struct {
 	// When set, the resource is deleted immediately by setting GracePeriodSeconds to 0.
 	Now bool
 	// When set, the spawned resources created by a job are also deleted
-	DeleteionPropagation bool
+	DeletionPropagation bool
 }


### PR DESCRIPTION
Solves issue where deleting a job does not delete its child resources.
Solved by adding DeletionPropagationBackground as part of the delete options for pods.