### PR TITLE
Replaced periods with dashes to follow K8's name constraints

### DIFF
--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/wish/ctl/cmd/util/parsing"
@@ -60,6 +61,9 @@ If no container is set, it will use the first one.`,
 						return errors.New("Unable to get hostname of machine")
 					}
 				}
+
+				//Replace periods with dashes to follow K8's name constraints
+				user = strings.Replace(user, ".", "-", -1) 
 
 				// We get the pod through the name label
 				podName := fmt.Sprintf("%s-%s", nameOfPod, user)

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/wish/ctl/pkg/client"
@@ -26,6 +27,9 @@ func downCmd(c *client.Client) *cobra.Command {
 					return errors.New("Unable to get hostname of machine")
 				}
 			}
+
+			//Replace periods with dashes to follow K8's name constraints
+			user = strings.Replace(user, ".", "-", -1) 
 
 			// Find existing jobs
 			jobs, err := c.FindJobs([]string{}, "", []string{fmt.Sprintf("%s-%s", appName, user)},

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -48,6 +48,9 @@ If the pod has multiple containers, it will choose the first container found.`,
 				}
 			}
 
+			//Replace periods with dashes to follow K8's name constraints
+			user = strings.Replace(user, ".", "-", -1) 
+			
 			// We get the pod through the name label
 			podName := fmt.Sprintf("%s-%s", appName, user)
 			lm, _ := parsing.LabelMatch(fmt.Sprintf("name=%s", podName))

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -101,6 +101,9 @@ func upCmd(c *client.Client) *cobra.Command {
 								}
 							}
 
+							//Replace periods with dashes to follow K8's name constraints
+							user = strings.Replace(user, ".", "-", -1) 
+							
 							// First, let's check if a job is already running. We want to limit 1 job per user.
 							// We find the job using its name '<app name>-<host name>' eg 'foo-bar'
 							jobs, err := c.FindJobs([]string{}, "", []string{fmt.Sprintf("%s-%s", appName, user)},


### PR DESCRIPTION
### _**Issue**_
If a hostname includes a period, creating a job would fail as it does not follow the [name constraints](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names) for Kubernetes Pod. 
`: Invalid value: "merchant-oneoff-pod-phariharan.local.subdomain": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')`

The Mac OS users have a default `.local` in fully qualified domain name which is return by the kernel as the hostname. This would cause the `ctl up` command to throw an error. 

### _**Fix**_

Replacing the periods with dashes is a fix for this issue for any user that has a period (or domain name) in the hostname 
