### PR TITLE
ITA-2304

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/wish/ctl/cmd/util/config"
@@ -66,10 +67,11 @@ If the pod has multiple containers, it will choose the first container found.`,
 				fmt.Printf("No existing pods were found. Creating a new ad hoc pod by running `ctl up %s`\n",
 					appName)
 				// Invoke the `ctl up` command 
-
 				if err := upCmd(c).RunE(cmd, args); err != nil {
 					return fmt.Errorf("Failed to create ad hoc pod: %v", err)
 				} 
+				time.Sleep(time.Second * 5) // Delay after invoking command to allow clusters to update
+				
 				pods, err = c.ListPodsOverContexts(ctxs, namespace, options)
 				if err != nil {
 					return err

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -60,8 +60,20 @@ If the pod has multiple containers, it will choose the first container found.`,
 			if err != nil {
 				return err
 			}
+			
+			// Create a new pod if no existing pods were found
 			if len(pods) < 1 {
-				return fmt.Errorf("No pod found, try running `ctl up %s` to start your pod", appName)
+				fmt.Printf("No existing pods were found. Creating a new ad hoc pod by running `ctl up %s`\n",
+					appName)
+				// Invoke the `ctl up` command 
+
+				if err := upCmd(c).RunE(cmd, args); err != nil {
+					return fmt.Errorf("Failed to create ad hoc pod: %v", err)
+				} 
+				pods, err = c.ListPodsOverContexts(ctxs, namespace, options)
+				if err != nil {
+					return err
+				}
 			}
 
 			pod := pods[0]


### PR DESCRIPTION
## **Issue**
When the `ctl login APPNAME` command was run with no pods to execute it, the ctl tool would exit the program and ask the user to run the `ctl up APPNAME` command. This is not efficient as the user has to run two commands.


## **Fix**
To issue this issue, the `ctl login APPNAME` is coupled with `ctl up APPNAME`when no existing pods are found to start a new adhoc job to create a pod and then login. 

An example of this fix is show below:

> ctl git:(couple_login_up_cmds) ✗ ./main login merch-be
> No existing pods were found. Creating a new ad hoc pod by running `ctl up merch-be`
> WARN: App name not active in app-01-prod.k8s.local. Manifest file: 
> WARN: App name not active in app-22-tahoe.k8s.local. Manifest file: 
> exceuting command kubectl apply -f - --context=app-05-dev.k8s.local
> Running merch-be with a deadline of 43200 seconds. CPU: 0.5, Memory: 4Gi...
> JOB: merch-be-priyanka
> CONTEXT: app-05-dev.k8s.local
> 
> Use `ctl login merch-be` to sh into your pod
> 
> job.batch/merch-be-priyanka created
> Running following commands in pod: /bin/bash -c ""/bin/bash /home/app/clroot/sweeper/scripts/infra/ctladhocjobs.sh && /bin/bash""
> Use `ctl cp in merch-be <files> -o <destination>` to copy files into pod
> Use `ctl cp out merch-be <files> -o <destination>` to copy files out of pod
> Use `ctl cp -h` for more info about file copying
> 
> exceuting command kubectl exec -i -t merch-be-priyanka-jrzkk --container=merchant-oneoff-pod-priyanka --context=app-05-dev.k8s.local --namespace=merchant-oneoff -- /bin/bash -c ""/bin/bash /home/app/clroot/sweeper/scripts/infra/ctladhocjobs.sh && /bin/bash""
> alias merch-python="CL_HOME=/production/merchant/current; PYTHONPATH=/production/merchant/current; /home/app/virtualenv/bin/python"
> alias wish-python="CL_HOME=/production/sweeper/current; PYTHONPATH=/production/sweeper/current; /home/app/virtualenv/bin/python"
> alias merch-dbshell="/home/app/virtualenv/bin/python /home/app/clroot/sweeper/merchant_dashboard/dbshell.py --env=be_prod"
> alias wish-dbshell="/home/app/virtualenv/bin/python /home/app/clroot/sweeper/dbshell.py --env=be_prod"
> 
> Please run `source ~/.ctladhocjobs` to use
> app@merch-be-priyanka-jrzkk:~$ `