### PR TITLE
Add --python flag to run python script or start a python shell

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -37,6 +37,7 @@ If the pod has multiple containers, it will choose the first container found.`,
 			namespace, _ := cmd.Flags().GetString("namespace")
 			container, _ := cmd.Flags().GetString("container")
 			user, _ := cmd.Flags().GetString("user")
+			python, _ := cmd.Flags().GetString("python")
 
 			appName := args[0]
 
@@ -102,6 +103,14 @@ If the pod has multiple containers, it will choose the first container found.`,
 				}
 				loginCommand = runs[appName].LoginCommand
 			}
+			// If python flag is present, the login command is overwritten to run the python script or start python shell
+			if python != "" {
+				loginCommand = []string{ "/home/app/virtualenv/bin/python"}
+				defaultVal := cmd.Flags().Lookup("python").NoOptDefVal
+				if python != defaultVal {
+					loginCommand = append(loginCommand,python)
+				}
+			}
 			// If no loginCommand is supplied then default to bash
 			if len(loginCommand) < 1 {
 				fmt.Printf("Using default command: %v\n", DefaultLoginCommand)
@@ -137,6 +146,8 @@ If the pod has multiple containers, it will choose the first container found.`,
 
 	cmd.Flags().StringP("container", "c", "", "Specify the container")
 	cmd.Flags().StringP("user", "u", "", "Name that is used for ad hoc jobs. Defaulted to hostname.")
+	cmd.Flags().StringP("python", "p", "", "Name of the python script to run in the pod. If no argument is passed, a python shell will be started ")
+	cmd.Flags().Lookup("python").NoOptDefVal = "default" // Hack to allow flag to be passed without arguments
 
 	return cmd
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -147,7 +147,7 @@ If the pod has multiple containers, it will choose the first container found.`,
 	cmd.Flags().StringP("container", "c", "", "Specify the container")
 	cmd.Flags().StringP("user", "u", "", "Name that is used for ad hoc jobs. Defaulted to hostname.")
 	cmd.Flags().StringP("python", "p", "", "Name of the python script to run in the pod. If no argument is passed, a python shell will be started ")
-	cmd.Flags().Lookup("python").NoOptDefVal = "default" // Hack to allow flag to be passed without arguments
+	cmd.Flags().Lookup("python").NoOptDefVal = "default" // Default value when `python` flag is passed in without any options
 
 	return cmd
 }


### PR DESCRIPTION
[Create a `--python` flag for ctl adhoc jobs](https://jira.wish.site/browse/ITA-2307) to allow the user to either run a python script using the login command or to quickly start a python shell 

Previously, the user would have to login into the pod and then run the script. With this `python` flag, the user can run pass the script as a option for the python flag and use the `login` in command to login and run the script
If no file is specified, the user will be dropped into a python shell

Examples of this python flag :
Creating a sample file and copying it into the pod to run:
```
➜  ctl git:(python_option) ✗ echo 'print("TEST PYTHON FILE")' > test.py
➜  ctl git:(python_option) ✗ ./main cp in wish-be test.py               
Available containers are: wish-oneoff-pod-priyanka, statsd-exporter, fluentd, memcached, logrotate, katalog-sync-sidecar, jaeger-agent
No container specified, defaulting to the first container: wish-oneoff-pod-priyanka

Copying files into POD wish-be-priyanka-4jtlq in NAMESPACE wish-oneoff and CONTEXT app-04-stage.k8s.local

Copying files from: test.py
Placing them in: /tmp/ctl
exceuting command kubectl cp test.py wish-oneoff/wish-be-priyanka-4jtlq:/tmp/ctl --context=app-04-stage.k8s.local --container=wish-oneoff-pod-priyanka
```
1. Passing in the python file as an argument 
```
➜  ctl git:(python_option) ✗ ./main login wish-be --python=/tmp/ctl             
Running following commands in pod: /home/app/virtualenv/bin/python /tmp/ctl
Use `ctl cp in wish-be <files> -o <destination>` to copy files into pod
Use `ctl cp out wish-be <files> -o <destination>` to copy files out of pod
Use `ctl cp -h` for more info about file copying

exceuting command kubectl exec -i -t wish-be-priyanka-4jtlq --container=wish-oneoff-pod-priyanka --context=app-04-stage.k8s.local --namespace=wish-oneoff -- /home/app/virtualenv/bin/python /tmp/ctl
TEST PYTHON FILE

```
2. `--python` flag with no arguments
```
➜  ctl git:(python_option) ✗ ./main login wish-be --python         
Running following commands in pod: /home/app/virtualenv/bin/python
Use `ctl cp in wish-be <files> -o <destination>` to copy files into pod
Use `ctl cp out wish-be <files> -o <destination>` to copy files out of pod
Use `ctl cp -h` for more info about file copying

exceuting command kubectl exec -i -t wish-be-priyanka-4jtlq --container=wish-oneoff-pod-priyanka --context=app-04-stage.k8s.local --namespace=wish-oneoff -- /home/app/virtualenv/bin/python
Python 2.7.12 (default, Jan  9 2017, 12:16:27) 
[GCC 4.8.4] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> %       
```    

