### PR TITLE
ITA-1209 : Add status flag to filter pods by the current status.phase

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -158,6 +158,7 @@ The names are regex expressions. ` + "\n\n" + describeResourceStr(),
 	}
 
 	cmd.Flags().Bool("show-events", true, "If true, display events related to the described object.")
+	cmd.Flags().StringP("status", "s", "", "Filter pods by specified status")
 
 	return cmd
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -107,6 +107,7 @@ Optionally, it filters through names match any of the regular expressions set.` 
 	}
 
 	cmd.Flags().StringSlice("label-columns", nil, "Prints with columns that contain the value of the specified label")
+	cmd.Flags().StringP("status", "s", "", "Filter pods by specified status")
 
 	return cmd
 }

--- a/cmd/util/parsing/options_test.go
+++ b/cmd/util/parsing/options_test.go
@@ -54,6 +54,7 @@ func TestAllOptions(t *testing.T) {
 			},
 		}
 		cmd.Flags().StringArrayP("label", "l", nil, "blah")
+		cmd.Flags().StringP("status", "s", "", "test")
 		cmd.SetArgs(test.flags)
 
 		_, err := cmd.ExecuteC()

--- a/pkg/client/filter/status.go
+++ b/pkg/client/filter/status.go
@@ -1,0 +1,8 @@
+package filter
+
+import v1 "k8s.io/api/core/v1"
+
+// StatusMatch is used to filter pods by status
+type StatusMatch struct {
+	State v1.PodPhase
+}

--- a/pkg/client/listpods.go
+++ b/pkg/client/listpods.go
@@ -25,7 +25,7 @@ func (c *Client) ListPods(context string, namespace string, options ListOptions)
 	for _, pod := range pods.Items {
 		p := types.PodDiscovery{context, pod}
 		c.Transform(&p)
-		if filter.MatchLabel(p, options.LabelMatch) && (options.Search == nil || options.Search.MatchString(p.Name)) {
+		if filter.MatchLabel(p, options.LabelMatch) && (options.Search == nil || options.Search.MatchString(p.Name)) && (options.StatusMatch.State == "" || p.Status.Phase == options.StatusMatch.State) {
 			items = append(items, p)
 		}
 	}

--- a/pkg/client/logpods.go
+++ b/pkg/client/logpods.go
@@ -12,7 +12,7 @@ import (
 
 // LogPodOverContexts retrieves logs of a single pod (uses first found if multiple)
 func (c *Client) LogPodOverContexts(contexts []string, namespace, name, container string, options LogOptions) (*rest.Request, error) {
-	pod, container, err := c.FindPodWithContainer(contexts, namespace, name, container, ListOptions{options.LabelMatch, nil})
+	pod, container, err := c.FindPodWithContainer(contexts, namespace, name, container, ListOptions{options.LabelMatch, options.StatusMatch, nil})
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +28,7 @@ func (c *Client) LogPodOverContexts(contexts []string, namespace, name, containe
 
 // LogPodsOverContexts retrieves logs of multiple pods (uses first found if multiple)
 func (c *Client) LogPodsOverContexts(contexts []string, namespace, container string, options LogOptions) (io.Reader, error) {
-	pods, err := c.ListPodsOverContexts(contexts, namespace, ListOptions{options.LabelMatch, options.Search})
+	pods, err := c.ListPodsOverContexts(contexts, namespace, ListOptions{options.LabelMatch, options.StatusMatch, options.Search})
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (c *Client) LogPod(context, namespace, name, container string, options LogO
 
 	// Find first container
 	if container == "" || namespace == "" {
-		pod, err := c.findPod([]string{context}, namespace, name, ListOptions{options.LabelMatch, nil})
+		pod, err := c.findPod([]string{context}, namespace, name, ListOptions{options.LabelMatch, options.StatusMatch, nil})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -10,6 +10,8 @@ import (
 type ListOptions struct {
 	// Filtering by labels
 	filter.LabelMatch
+	// Filtering by status
+	filter.StatusMatch
 	// Filtering by name
 	Search *regexp.Regexp
 }
@@ -24,6 +26,8 @@ type GetOptions struct {
 type LogOptions struct {
 	// Filtering by labels
 	filter.LabelMatch
+	// Filtering by status
+	filter.StatusMatch
 	// When set streams logs
 	Follow bool
 	// Filtering by name


### PR DESCRIPTION
[Ctl: Add -a/--a flag for getting pods](https://jira.wish.site/browse/ITA-1209)
The get pods retrieves all pods of all statuses - `Pending, Running, Succeeded, Failed, Unknown.`
 
Since the `get pods` command already retrieves all pods, this ticket addresses a `status` flag that allows user to filter the pods by the current Status.Phase

`  -s, --status string           Filter pods by specified status
`


Example: 

```
➜  ctl git:(add_a_flag) ✗ ./main get pods -s Failed                                                
CONTEXT                 NAMESPACE      NAME                                                  READY  STATUS  RESTARTS  AGE         K8S_ENV  AZ
app-01-prod.k8s.local   kron           example-2-1591161485-jzlxd                            0/1    Failed  0         132h8m19s   prod     us-west-1a
app-01-prod.k8s.local   kron           example-2-1591161485-pjhjd                            0/1    Failed  0         132h8m26s   prod     us-west-1a
app-01-prod.k8s.local   merchant-cron  v3-oauth-api-daily-usage-report-1590645600-8666n      0/2    Failed  0         275h26m24s  prod     us-west-1a
app-01-prod.k8s.local   wish-cron      backup-route53-dns-to-s3-1590771707-lrgsb             0/2    Failed  0         240h24m44s  prod     us-west-1a
app-01-prod.k8s.local   wish-cron      bbsolr-query-payload-1591211321-m2dkk                 0/2    Failed  0         118h17m50s  prod     us-west-1a
app-03-stage.k8s.local  infra-cron     test-1590620590-t7kb7                                 0/1    Failed  0         282h23m21s  stage    us-west-1a
app-03-stage.k8s.local  infra-cron     test-1590620590-w9g4g                                 0/1    Failed  0         282h23m14s  stage    us-west-1a
app-03-stage.k8s.local  infra-cron     test-1590634420-nl8lx                                 0/1    Failed  0         278h32m51s  stage    us-west-1a
app-03-stage.k8s.local  infra-cron     test-1590634420-pgzzx                                 0/1    Failed  0         278h32m45s  stage    us-west-1a
app-03-stage.k8s.local  kron           test-example-1591220130-ppwzl                         0/1    Failed  0         115h50m55s  stage    us-west-1a
app-03-stage.k8s.local  kron           test-example-1591220130-zxtn5                         0/1    Failed  0         115h51m1s   stage    us-west-1a
app-03-stage.k8s.local  merchant-cron  test-merchant-1590667840-hx2wn                        0/2    Failed  0         269h15m51s  stage    us-west-1a
app-03-stage.k8s.local  merchant-cron  test-merchant-1590667943-q7crk                        0/2    Failed  0         269h14m8s   stage    us-west-1a
app-03-stage.k8s.local  merchant-cron  test-merchant-1590670638-ngfxs                        0/2    Failed  0         268h29m13s  stage    us-west-1a
app-03-stage.k8s.local  wish-cron      weekly-load-onesource-tax-treatment-1591574400-bck8n  0/2    Failed  0         17h26m27s   stage    us-west-1a
app-05-dev.k8s.local    linkerd        linkerd-heartbeat-1589912280-g7xfs                    0/1    Failed  0         479h2m56s   dev      us-west-1a
app-05-dev.k8s.local    linkerd        linkerd-heartbeat-1589912280-hl6vf                    0/1    Failed  0         478h57m15s  dev      us-west-1a

```

