### PR TITLE
Add support for prelogin commands

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -91,15 +91,7 @@ If the pod has multiple containers, it will choose the first container found.`,
 			if err != nil {
 				return err
 			}
-
-			// Build kubectl exec command
-			context := fmt.Sprintf("--context=%s", pod.Context)
-			namespace = fmt.Sprintf("--namespace=%s", pod.Namespace)
-			name := pod.Name
-			if container == "" { // If container flag is empty, grab first one
-				container = fmt.Sprintf("--container=%s", pod.Spec.Containers[0].Name)
-			}
-			// Get preLoginCommand to run before logging into the pod and loginCommand to use with kubectl exec from the config file and
+			// Get preLoginCommand to run before logging into the pod and loginCommand to use with kubectl exec from the config file
 			preLoginCommand := [][]string{}
 			loginCommand := []string{}
 			if rawruns, ok := m[pod.Context]["_run"]; ok {
@@ -112,9 +104,16 @@ If the pod has multiple containers, it will choose the first container found.`,
 				preLoginCommand = runs[appName].PreLogin
 			}
 
+			// Build kubectl exec command
+			context := fmt.Sprintf("--context=%s", pod.Context)
+			namespace = fmt.Sprintf("--namespace=%s", pod.Namespace)
+			name := pod.Name
+			if container == "" { // If container flag is empty, grab first one
+				container = fmt.Sprintf("--container=%s", pod.Spec.Containers[0].Name)
+			}
+
 			// If preloginCommand is supplied then run those commands
-			// preloginCommand form : {{kubectl cmd, bash args}, { kubectl cmd, bash args}, ...}
-			// bash args are optional
+			// preloginCommand form (bash args are optional): {{kubectl cmd, bash args}, { kubectl cmd, bash args}, ...}
 			if len(preLoginCommand) > 0 {
 				for _, cmd := range  preLoginCommand {
 					// Setup `kubectl exec` command
@@ -144,7 +143,6 @@ If the pod has multiple containers, it will choose the first container found.`,
 				"Use `ctl cp out %s <files> -o <destination>` to copy files out of pod\n"+
 				"Use `ctl cp -h` for more info about file copying\n\n",
 				strings.Join(loginCommand, " "), appName, appName)
-
 
 			combinedArgs := append(
 				[]string{"exec", "-i", "-t", name, container, context, namespace, "--"},

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -125,12 +125,12 @@ If the pod has multiple containers, it will choose the first container found.`,
 			fmt.Printf("Populating current pod %s with dbshell history from other user pods \n\n", name)
 
 			// Check if dbshell history file exists and then append it to a local file `.py_dbshell`
-			copyFile := []string{ "-c", "\"\"kubectl exec -i" + " " + name + " " + container + " " + context + " " + namespace + " -- /bin/bash -c " +
+			copyFile := []string{ "-c", "\"\"kubectl exec -i " + name + " " + container + " " + context + " " + namespace + " -- /bin/bash -c " +
 					"\"[ -f .ipython/profile_default/history.sqlite ] && cat .ipython/profile_default/history.sqlite\"\"\" >> ~/.py_dbshell"}
 			exec.Command("bash", copyFile...).CombinedOutput()
 
 			// Populate the pod's dbshell history file with the local file `.py_dbshell` if it exists
-			populateDbshell := []string{"-c", "\"\"[ -f ~/.py_dbshell ] && kubectl exec -i" + " "+name + " " +container + " " +context + " " +namespace + " -- /bin/bash -c " +
+			populateDbshell := []string{"-c", "\"\"[ -f ~/.py_dbshell ] && kubectl exec -i " + name + " " + container + " " + context + " " + namespace + " -- /bin/bash -c " +
 					"\"( [ -f .ipython/profile_default/history.sqlite ] || mkdir -p .ipython/profile_default && touch .ipython/profile_default/history.sqlite ) " +
 					"&& cat > .ipython/profile_default/history.sqlite\"\"\" < ~/.py_dbshell"}
 			exec.Command("bash", populateDbshell...).CombinedOutput()

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -23,7 +23,7 @@ type runDetails struct {
 	Resources    resource `json:"resources"`
 	Active       bool     `json:"active"`
 	Manifest     string   `json:"manifest"`
-	PreLogin	 []string `json:"pre_login_command,omitempty"`
+	PreLogin	 [][]string `json:"pre_login_command,omitempty"`
 	LoginCommand []string `json:"login_command"`
 }
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -23,8 +23,8 @@ type runDetails struct {
 	Resources    resource `json:"resources"`
 	Active       bool     `json:"active"`
 	Manifest     string   `json:"manifest"`
-	PreLogin	 []string `json:"pre_login"`
-	LoginCommand []string `json:"login_command,omitempty"`
+	PreLogin	 []string `json:"pre_login_command,omitempty"`
+	LoginCommand []string `json:"login_command"`
 }
 
 type resource struct {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -23,7 +23,8 @@ type runDetails struct {
 	Resources    resource `json:"resources"`
 	Active       bool     `json:"active"`
 	Manifest     string   `json:"manifest"`
-	LoginCommand []string `json:"login_command"`
+	PreLogin	 []string `json:"pre_login"`
+	LoginCommand []string `json:"login_command,omitempty"`
 }
 
 type resource struct {


### PR DESCRIPTION
### **_Issue_**
Add support for `prelogin` commands. Currently, `ctl` login command drops the user into a bash shell in the pod with a `loginCommand` supplied in the ctl config file. This PR addresses support for a` prelogin` field _(optional)_  in the config file 

### _**Fix**_
Before logging into the pod, the prelogin commands are fetched from the config file and executing in the container remotely. 
The current format of the prelogin command is `{{Kubectl cmd, bash args ...}, {Kubectl cmd, bash args ...},...}`. The bash args are optional and would allow users to specify bash arguments with the kubectl command if required.

### **_Examples_**
prelogin Command example:
 ```
preLoginCommand = [][]string{ {"/bin/bash -c '( [ -f ~/.ipython/profile_default/history.sqlite ] && cat ~/.ipython/profile_default/history.sqlite || true )'", "| cat - ~/.py_dbshell > ~/.py_dbshell.tmp && mv ~/.py_dbshell.tmp ~/.py_dbshell"},
   {"/bin/bash -c '( [ -f ~/.ipython/profile_default/history.sqlite ] || mkdir -p ~/.ipython/profile_default && touch ~/.ipython/profile_default/history.sqlite ) && cat > ~/.ipython/profile_default/history.sqlite'", "<> ~/.py_dbshell"}}
```
The above prelogin command would be run as two different bash commands :

```
exceuting command bash -c ""kubectl exec -i wish-be-priyanka-gffkt --container=wish-oneoff-pod-priyanka --context=app-05-dev.k8s.local --namespace=wish-oneoff -- /bin/bash -c '( [ -f ~/.ipython/profile_default/history.sqlite ] && cat ~/.ipython/profile_default/history.sqlite || true )' "" | cat - ~/.py_dbshell > ~/.py_dbshell.tmp && mv ~/.py_dbshell.tmp ~/.py_dbshell
```

```
exceuting command bash -c ""kubectl exec -i wish-be-priyanka-gffkt --container=wish-oneoff-pod-priyanka --context=app-05-dev.k8s.local --namespace=wish-oneoff -- /bin/bash -c '( [ -f ~/.ipython/profile_default/history.sqlite ] || mkdir -p ~/.ipython/profile_default && touch ~/.ipython/profile_default/history.sqlite ) && cat > ~/.ipython/profile_default/history.sqlite' "" <> ~/.py_dbshell
```