### PR TITLE
[ITA-2312] - Display pod's job deadline by finding job's active Deadline Seconds

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -80,7 +80,16 @@ If the pod has multiple containers, it will choose the first container found.`,
 			}
 
 			pod := pods[0]
-
+			// Find the pod's job deadline
+			for _, owners := range pod.OwnerReferences {
+				if owners.Kind == "Job" {
+					jobLM, _ := parsing.LabelMatch(fmt.Sprintf("name=%s", owners.Name))
+					option := client.ListOptions{LabelMatch: jobLM}
+					list, _ := c.ListJobsOverContexts(ctxs, namespace, option)
+					fmt.Printf("Running %v with a deadline of %v seconds.\n", appName, *list[0].Spec.ActiveDeadlineSeconds)
+					break
+				}
+			}
 			podPhase := pod.Status.Phase
 			// Check to see if pod is running
 			if podPhase == v1.PodPending {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -80,13 +80,15 @@ If the pod has multiple containers, it will choose the first container found.`,
 			}
 
 			pod := pods[0]
+
 			// Find the pod's job deadline
+			deadline := 0
 			for _, owners := range pod.OwnerReferences {
 				if owners.Kind == "Job" {
 					jobLM, _ := parsing.LabelMatch(fmt.Sprintf("name=%s", owners.Name))
 					option := client.ListOptions{LabelMatch: jobLM}
 					list, _ := c.ListJobsOverContexts(ctxs, namespace, option)
-					fmt.Printf("Running %v with a deadline of %v seconds.\n", appName, *list[0].Spec.ActiveDeadlineSeconds)
+					deadline = int(*list[0].Spec.ActiveDeadlineSeconds)
 					break
 				}
 			}
@@ -156,6 +158,7 @@ If the pod has multiple containers, it will choose the first container found.`,
 				loginCommand = []string{DefaultLoginCommand}
 			}
 
+			fmt.Printf("Running %v with a deadline of %v seconds\n", appName, deadline)
 			fmt.Printf("Running following commands in pod: %s\n"+
 				"Use `ctl cp in %s <files> -o <destination>` to copy files into pod\n"+
 				"Use `ctl cp out %s <files> -o <destination>` to copy files out of pod\n"+

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -81,6 +81,12 @@ If the pod has multiple containers, it will choose the first container found.`,
 
 			pod := pods[0]
 
+			podPhase := pod.Status.Phase
+			// Check to see if pod is running
+			if podPhase == v1.PodPending {
+				return fmt.Errorf("Pod %s is still being created", pod.Name)
+			}
+
 			// Find the pod's job deadline
 			deadline := 0
 			for _, owners := range pod.OwnerReferences {
@@ -91,11 +97,6 @@ If the pod has multiple containers, it will choose the first container found.`,
 					deadline = int(*list[0].Spec.ActiveDeadlineSeconds)
 					break
 				}
-			}
-			podPhase := pod.Status.Phase
-			// Check to see if pod is running
-			if podPhase == v1.PodPending {
-				return fmt.Errorf("Pod %s is still being created", pod.Name)
 			}
 
 			// Get the login command from the ctl-config configmap


### PR DESCRIPTION
### Issue
Display death time of jobs in ctl adhoc jobs - https://jira.wish.site/browse/ITA-2312
Currently on bring up an adhoc job at this, the script[ updates the activeDeadlineSeconds](https://github.com/ContextLogic/k8s/blob/master/apps/kube-system/ctl.jsonnet#L69) attribute and prints it. However, it does not print the death time on logging on into to the pod
### Fix
The activeDeadlineSeconds attribute is attached to the Job spec and not the pod spec. To print the death time/activeDeadline seconds, the fix iterates through the Owner Resources attribute to find it's job name and filters all contexts to get the job specs. 
Although filtering through jobs to find the specific job and it's activeDeadlineSeconds increases the delay from roughly _**804.146µs**_ to **_814.149686ms_** / **_814000.149686us_**
