### PR TITLE
Convert hostname to lower case to meet K8 naming constraints 

### DIFF
--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -62,7 +62,7 @@ If no container is set, it will use the first one.`,
 					}
 				}
 
-				//Replace periods with dashes and convert to lower case to follow K8's name constraints
+				// Replace periods with dashes and convert to lower case to follow K8's name constraints
 				user = strings.Replace(user, ".", "-", -1)
 				user = strings.ToLower(user)
 

--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -62,8 +62,9 @@ If no container is set, it will use the first one.`,
 					}
 				}
 
-				//Replace periods with dashes to follow K8's name constraints
-				user = strings.Replace(user, ".", "-", -1) 
+				//Replace periods with dashes and convert to lower case to follow K8's name constraints
+				user = strings.Replace(user, ".", "-", -1)
+				user = strings.ToLower(user)
 
 				// We get the pod through the name label
 				podName := fmt.Sprintf("%s-%s", nameOfPod, user)

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -28,7 +28,7 @@ func downCmd(c *client.Client) *cobra.Command {
 				}
 			}
 
-			//Replace periods with dashes and convert to lower case to follow K8's name constraints
+			// Replace periods with dashes and convert to lower case to follow K8's name constraints
 			user = strings.Replace(user, ".", "-", -1)
 			user = strings.ToLower(user)
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -28,8 +28,9 @@ func downCmd(c *client.Client) *cobra.Command {
 				}
 			}
 
-			//Replace periods with dashes to follow K8's name constraints
-			user = strings.Replace(user, ".", "-", -1) 
+			//Replace periods with dashes and convert to lower case to follow K8's name constraints
+			user = strings.Replace(user, ".", "-", -1)
+			user = strings.ToLower(user)
 
 			// Find existing jobs
 			jobs, err := c.FindJobs([]string{}, "", []string{fmt.Sprintf("%s-%s", appName, user)},

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -50,8 +50,9 @@ If the pod has multiple containers, it will choose the first container found.`,
 				}
 			}
 
-			//Replace periods with dashes to follow K8's name constraints
-			user = strings.Replace(user, ".", "-", -1) 
+			//Replace periods with dashes and convert to lower case to follow K8's name constraints
+			user = strings.Replace(user, ".", "-", -1)
+			user = strings.ToLower(user)
 			
 			// We get the pod through the name label
 			podName := fmt.Sprintf("%s-%s", appName, user)
@@ -114,7 +115,7 @@ If the pod has multiple containers, it will choose the first container found.`,
 					return fmt.Errorf("Failed to get rawruns from ctl-config: %v", err)
 				}
 				loginCommand = runs[appName].LoginCommand
-				preLoginCommand = runs[appName].PreLogin
+				preLoginCommand = runs[appName].PreLoginCommand
 			}
 
 			// Build kubectl exec command
@@ -139,6 +140,8 @@ If the pod has multiple containers, it will choose the first container found.`,
 						[]string{"-c"},
 						strings.Join(preLoginCmd," "),
 					)
+
+					fmt.Printf("command : %s\n\n", combinedArgs)
 					err =  exec.Command("bash", combinedArgs...).Run()
 					if err != nil {
 						return fmt.Errorf("Failed to run pre-login commands: %v", err)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -50,7 +50,7 @@ If the pod has multiple containers, it will choose the first container found.`,
 				}
 			}
 
-			//Replace periods with dashes and convert to lower case to follow K8's name constraints
+			// Replace periods with dashes and convert to lower case to follow K8's name constraints
 			user = strings.Replace(user, ".", "-", -1)
 			user = strings.ToLower(user)
 			
@@ -115,7 +115,7 @@ If the pod has multiple containers, it will choose the first container found.`,
 					return fmt.Errorf("Failed to get rawruns from ctl-config: %v", err)
 				}
 				loginCommand = runs[appName].LoginCommand
-				preLoginCommand = runs[appName].PreLoginCommand
+				preLoginCommand = runs[appName].PreLogin
 			}
 
 			// Build kubectl exec command
@@ -140,8 +140,6 @@ If the pod has multiple containers, it will choose the first container found.`,
 						[]string{"-c"},
 						strings.Join(preLoginCmd," "),
 					)
-
-					fmt.Printf("command : %s\n\n", combinedArgs)
 					err =  exec.Command("bash", combinedArgs...).Run()
 					if err != nil {
 						return fmt.Errorf("Failed to run pre-login commands: %v", err)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -22,8 +22,8 @@ import (
 type runDetails struct {
 	Resources    resource `json:"resources"`
 	Active       bool     `json:"active"`
+	PreLoginCommand	 [][]string `json:"pre_login_command,omitempty"`
 	Manifest     string   `json:"manifest"`
-	PreLogin	 [][]string `json:"pre_login_command,omitempty"`
 	LoginCommand []string `json:"login_command"`
 }
 
@@ -126,8 +126,9 @@ func upCmd(c *client.Client) *cobra.Command {
 								}
 							}
 
-							//Replace periods with dashes to follow K8's name constraints
-							user = strings.Replace(user, ".", "-", -1) 
+							//Replace periods with dashes and convert to lower case to follow K8's name constraints
+							user = strings.Replace(user, ".", "-", -1)
+							user = strings.ToLower(user)
 							
 							// First, let's check if a job is already running. We want to limit 1 job per user.
 							// We find the job using its name '<app name>-<host name>' eg 'foo-bar'

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -22,8 +22,8 @@ import (
 type runDetails struct {
 	Resources    resource `json:"resources"`
 	Active       bool     `json:"active"`
-	PreLoginCommand	 [][]string `json:"pre_login_command,omitempty"`
 	Manifest     string   `json:"manifest"`
+	PreLogin	 [][]string `json:"pre_login_command,omitempty"`
 	LoginCommand []string `json:"login_command"`
 }
 
@@ -126,7 +126,7 @@ func upCmd(c *client.Client) *cobra.Command {
 								}
 							}
 
-							//Replace periods with dashes and convert to lower case to follow K8's name constraints
+							// Replace periods with dashes and convert to lower case to follow K8's name constraints
 							user = strings.Replace(user, ".", "-", -1)
 							user = strings.ToLower(user)
 							


### PR DESCRIPTION
### Issue
Hostname with upper case alphanumeric characters will fail the K8 naming validation
 
`Invalid value: "merchant-oneoff-pod-Priyanka-local": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
`

### Fix

Convert hostname to lower case on `login`, `up`,` down`, and` cp`.

