### PR TITLE
Print pre-login command stack trace

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -99,7 +99,7 @@ If the pod has multiple containers, it will choose the first container found.`,
 						deadline = int(*list[0].Spec.ActiveDeadlineSeconds)
 						break
 					} else {
-						fmt.Errorf("Failed to find pod's job: %v", err)
+						return fmt.Errorf("Failed to find pod's job: %v", err)
 					}
 				}
 			}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -95,8 +95,12 @@ If the pod has multiple containers, it will choose the first container found.`,
 					jobLM, _ := parsing.LabelMatch(fmt.Sprintf("name=%s", owners.Name))
 					option := client.ListOptions{LabelMatch: jobLM}
 					list, _ := c.ListJobsOverContexts(ctxs, namespace, option)
-					deadline = int(*list[0].Spec.ActiveDeadlineSeconds)
-					break
+					if len(list) > 0 {
+						deadline = int(*list[0].Spec.ActiveDeadlineSeconds)
+						break
+					} else {
+						fmt.Errorf("Failed to find pod's job: %v", err)
+					}
 				}
 			}
 
@@ -140,7 +144,12 @@ If the pod has multiple containers, it will choose the first container found.`,
 						[]string{"-c"},
 						strings.Join(preLoginCmd," "),
 					)
-					err =  exec.Command("bash", combinedArgs...).Run()
+					fmt.Printf("Running pre-login command: %s \n", combinedArgs)
+					command :=  exec.Command("bash", combinedArgs...)
+					command.Stdout = os.Stdout
+					command.Stderr = os.Stderr
+					command.Stdin = os.Stdin
+					err =  command.Run()
 					if err != nil {
 						return fmt.Errorf("Failed to run pre-login commands: %v", err)
 					}


### PR DESCRIPTION
### Issue
Currently, when `ctl login` is run and the pre-login commands are executed, the standard output and error are not printed to the console which made debugging  pre-login commands failures difficult.

### Fix
Standard input, output and error are logged to the console. 
Added error handling when `ctl login` tries to login into a pod that was just deleted ( pod is active but job is deleted )

### Example

````
Running pre-login command: [-c ""kubectl exec -i wish-be-riyanka-local-ds98v --container=wish-oneoff-pod-riyanka-local --context=app-01-prod.k8s.local --namespace=wish-oneoff -- : "" ; bash -c "python ctl-dbshell.py || ( wget https://wish-tools.s3-us-west-1.amazonaws.com/ctl-dbshell.py && python ctl-dbshell.py )"] 
OCI runtime exec failed: exec failed: container_linux.go:348: starting container process caused "exec: \":\": executable file not found in $PATH": unknown
command terminated with exit code 126
/usr/local/Cellar/python@2/2.7.17_1/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python: can't open file 'ctl-dbshell.py': [Errno 2] No such file or directory
--2020-07-20 11:27:16--  https://wish-tools.s3-us-west-1.amazonaws.com/ctl-dbshell.py
Resolving wish-tools.s3-us-west-1.amazonaws.com (wish-tools.s3-us-west-1.amazonaws.com)... 52.219.117.1
Connecting to wish-tools.s3-us-west-1.amazonaws.com (wish-tools.s3-us-west-1.amazonaws.com)|52.219.117.1|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 2275 (2.2K) [text/x-python-script]
Saving to: ‘ctl-dbshell.py’

ctl-dbshell.py                             100%[========================================================================================>]   2.22K  --.-KB/s    in 0s      

2020-07-20 11:27:16 (15.2 MB/s) - ‘ctl-dbshell.py’ saved [2275/2275]

Copying pod dbshell commands to local dbshell file
Running pre-login command: [-c ""kubectl exec -i wish-be-riyanka-local-ds98v --container=wish-oneoff-pod-riyanka-local --context=app-01-prod.k8s.local --namespace=wish-oneoff -- /bin/bash -c '( [ -f ~/.ipython/profile_default/history.sqlite ] || mkdir -p ~/.ipython/profile_default && touch ~/.ipython/profile_default/history.sqlite ) && cat > ~/.ipython/profile_default/history.sqlite' "" <> ~/.dbshell.sqlite] 
````