### PR TITLE
Change references of kube-system to ctl to reflect namespace change

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Also, when running login, it will give the name of the pod spawned by the job so
 # Setup and Configuration
 This section refers to the optional setup on the server-side of configuration ctl for all users. To use the optional features of ctl (such as `ctl up`, `ctl down`, and `ctl login`), a ConfigMap should be added to clusters.
 
-This ConfigMap should be located in namespace `kube-system` and have name `ctl-config`.
+This ConfigMap should be located in namespace `ctl` and have name `ctl-config`.
 
 ## Adhoc Job Config Setup
 To use the ad hoc job feature above, the ctl-config must be configured in a certain way. This example will use [jsonnet](https://jsonnet.org/) to make the config file. This jsonnet can generate json and yaml files. Anything with `<text>` wrapped you should change to your specific needs.
@@ -177,7 +177,7 @@ To use the ad hoc job feature above, the ctl-config must be configured in a cert
         apiVersion: 'v1',
         kind: 'ConfigMap',
         metadata: {
-            namespace: 'kube-system',
+            namespace: 'ctl',
             name: 'ctl-config',
         },
         data: {

--- a/pkg/client/ctlext.go
+++ b/pkg/client/ctlext.go
@@ -22,7 +22,7 @@ func (c *Client) GetCtlExt() map[string]map[string]string {
 			continue
 		}
 
-		cf, err := ci.CoreV1().ConfigMaps("kube-system").Get("ctl-config", metav1.GetOptions{})
+		cf, err := ci.CoreV1().ConfigMaps("ctl").Get("ctl-config", metav1.GetOptions{})
 		if err != nil {
 			m[ctx] = nil
 			continue

--- a/pkg/client/ctlext_test.go
+++ b/pkg/client/ctlext_test.go
@@ -16,7 +16,7 @@ func generateCtlExt(data map[string]string) runtime.Object {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ctl-config",
-			Namespace: "kube-system",
+			Namespace: "ctl",
 		},
 		Data: data,
 	}


### PR DESCRIPTION
Move the configmap location to a namespace that is exclusive to ctl instead of the kube-system namespace which is shared with other apps.