### PR TITLE
Update ctl adhoc jobs to search for pods/jobs by the config namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Additional columns are added to get output from labels. These columns are set by
 
 ## Flags
 ### Namespace
-Most objects can be scoped to a namespace. By default, ctl operates on all namespaces, but you may specify a single namespace with the `-n, --namespace` flag. For more expensive operations, specifying contexts and namespaces can improve the performance.
+Most objects can be scoped to a namespace. By default, ctl will operate on the specified namespace in your ctl config for adhoc jobs but otherwise operates on all namespaces, but you may specify a single namespace with the `-n, --namespace` flag. For more expensive operations, specifying contexts and namespaces can improve the performance.
 
 ### Labels
 Objects can be filtered by labels. The cluster-level labels above are shorthands for these labels filters (`--k8s_env=dev` is equivalent to `-l k8s_env=dev`). Use flag `-l, --label`. You can set any number of labels together: `-l a=b,b=c -l c!=d` is valid.
@@ -157,8 +157,8 @@ Also, when running login, it will give the name of the pod spawned by the job so
 * `--container=<your container>`, will check the pod for the following container and run the command on that container. If no container is specified it will use the first one found if there are multiple containers.
 * `--python=<your python script>`, will run your python script if specified or start a python shell on login
 
-### ctl cp in/out POD SOURCE [flags]
-`ctl cp in/out POD SOURCE` will copy files into the pod (`ctl cp in`) or out of the pod (`ctl cp out`) using `kubectl cp`
+### ctl cp in/out APPNAME SOURCE [flags]
+`ctl cp in/out APPNAME SOURCE` will copy files into the adhoc job pod for the given app name(`ctl cp in`) or out of the pod (`ctl cp out`) using `kubectl cp`
 
 * `--out=<your output destination>`, the destination of the copied files. If no destination is set it will default to **/tmp/ctl**
 * `--container=<your container>`, will check the pod for the following container and run the command on that container. If no container is specified it will use the first one found if there are multiple containers.

--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -3,14 +3,11 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
-	"os/exec"
-	"strings"
-
 	"github.com/spf13/cobra"
-	"github.com/wish/ctl/cmd/util/parsing"
 	"github.com/wish/ctl/pkg/client"
 	v1 "k8s.io/api/core/v1"
+	"os"
+	"os/exec"
 )
 
 // func cpTest() {
@@ -36,87 +33,54 @@ If there are multiple pods with the same name, it will take the first pod it fin
 If no container is set, it will use the first one.`,
 		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctxs, _ := cmd.Flags().GetStringSlice("context")
-			namespace, _ := cmd.Flags().GetString("namespace")
 			container, _ := cmd.Flags().GetString("container")
 			out, _ := cmd.Flags().GetString("out")
-			options, err := parsing.ListOptions(cmd, nil)
-			if err != nil {
-				return err
-			}
+			user, _ := cmd.Flags().GetString("user")
 
 			inOrOut := args[0]
-			nameOfPod := args[1]
+			appName := args[1]
 			source := args[2]
 
-			customPod, _ := cmd.Flags().GetBool("custom-pod")
-			if customPod == false { // Find the pod created by ctl up
-				user, _ := cmd.Flags().GetString("user")
-
-				// Get hostname to use in job name if not supplied
-				if user == "" {
-					var err error
-					user, err = os.Hostname()
-					if err != nil {
-						return errors.New("Unable to get hostname of machine")
-					}
-				}
-
-				// Replace periods with dashes and convert to lower case to follow K8's name constraints
-				user = strings.Replace(user, ".", "-", -1)
-				user = strings.ToLower(user)
-
-				// We get the pod through the name label
-				podName := fmt.Sprintf("%s-%s", nameOfPod, user)
-				lm, _ := parsing.LabelMatch(fmt.Sprintf("name=%s", podName))
-				options := client.ListOptions{LabelMatch: lm}
-
-				pods, err := c.ListPodsOverContexts(ctxs, namespace, options)
+			// Get hostname to use in job name if not supplied
+			if user == "" {
+				var err error
+				user, err = os.Hostname()
 				if err != nil {
-					return err
+					return errors.New("Unable to get hostname of machine")
 				}
-				if len(pods) < 1 {
-					return fmt.Errorf("No pod found, try running `ctl up %s` to start your pod", nameOfPod)
-				}
-
-				pod := pods[0]
-
-				podPhase := pod.Status.Phase
-				// Check to see if pod is running
-				if podPhase == v1.PodPending {
-					return fmt.Errorf("Pod %s is still being created", pod.Name)
-				}
-
-				nameOfPod = pod.Name
 			}
 
-			// Find pod, if there are multiple pods, pick the first one
-			pod, container, err := c.FindPodWithContainer(ctxs, namespace, nameOfPod, container, options)
+			pod, _, _, err := c.FindAdhocPodAndAppDetails(appName, user)
 			if err != nil {
 				return err
 			}
+			if pod == nil {
+				return fmt.Errorf("No pod found, try running `ctl up %s` to start your pod", appName)
+			}
 
-			podNamespace := pod.Namespace
-			podName := pod.Name
-			podContext := pod.Context
+			podPhase := pod.Status.Phase
+			// Check to see if pod is running
+			if podPhase == v1.PodPending {
+				return fmt.Errorf("Pod %s is still being created", pod.Name)
+			}
 
 			// Build command to pass kubectl
 			outputFiles := out
 			sourceFiles := source
 			if inOrOut == ToPod {
-				fmt.Printf("\nCopying files into POD %s in NAMESPACE %s and CONTEXT %s\n", podName, podNamespace, podContext)
+				fmt.Printf("\nCopying files into POD %s in NAMESPACE %s and CONTEXT %s\n", pod.Name, pod.Namespace, pod.Context)
 
 				// Point destination to the pod: <namespace>/<pod>:<destination directory>
-				outputFiles = fmt.Sprintf("%s/%s:%s", podNamespace, podName, out)
+				outputFiles = fmt.Sprintf("%s/%s:%s", pod.Namespace, pod.Name, out)
 			} else if inOrOut == FromPod {
-				fmt.Printf("\nCopying files out of POD %s in NAMESPACE %s and CONTEXT %s\n", podName, podNamespace, podContext)
+				fmt.Printf("\nCopying files out of POD %s in NAMESPACE %s and CONTEXT %s\n", pod.Name, pod.Namespace, pod.Context)
 
 				// Set source from the pod: <namespace>/<pod>:<source directory>
-				sourceFiles = fmt.Sprintf("%s/%s:%s", podNamespace, podName, source)
+				sourceFiles = fmt.Sprintf("%s/%s:%s", pod.Namespace, pod.Name, source)
 			} else {
 				return errors.New("please use in or out to copy files/directories to and from the pods respectively")
 			}
-			context := fmt.Sprintf("--context=%s", podContext)
+			context := fmt.Sprintf("--context=%s", pod.Context)
 			if container != "" {
 				container = fmt.Sprintf("--container=%s", container)
 			}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bufio"
 	"errors"
-	"fmt"
 	"io"
 	"strings"
 
@@ -19,17 +18,6 @@ var supportedDeleteTypes = [][]string{
 	{"deployments", "deployment", "deploy"},
 	{"replicasets", "replicaset", "rs"},
 	{"cronjobs", "cronjob"},
-}
-
-func deleteResourceStr() string {
-	var str strings.Builder
-
-	fmt.Fprintln(&str, "Choose from the list of supported resources:")
-	for _, names := range supportedGetTypes {
-		fmt.Fprintf(&str, " * %s\n", names[0])
-	}
-
-	return str.String()
 }
 
 // Default Y/n

--- a/pkg/client/ctlext.go
+++ b/pkg/client/ctlext.go
@@ -16,15 +16,8 @@ func (c *Client) GetCtlExt() map[string]map[string]string {
 			continue
 		}
 
-		// Check if the cluster is connectable by attempting to fetch all configmaps
-		_, err = ci.CoreV1().ConfigMaps("").List(metav1.ListOptions{})
-		if err != nil {
-			continue
-		}
-
 		cf, err := ci.CoreV1().ConfigMaps("ctl").Get("ctl-config", metav1.GetOptions{})
 		if err != nil {
-			m[ctx] = nil
 			continue
 		}
 		m[ctx] = cf.Data

--- a/pkg/client/ctlext_test.go
+++ b/pkg/client/ctlext_test.go
@@ -34,7 +34,6 @@ func TestGetCtlExt(t *testing.T) {
 
 	ans := map[string]map[string]string{
 		"cluster1": {"_hidden": "true"},
-		"cluster2": nil,
 		"c4":       make(map[string]string),
 	}
 

--- a/pkg/client/findadhocjob.go
+++ b/pkg/client/findadhocjob.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"errors"
+	"encoding/json"
+	"fmt"
+	"github.com/wish/ctl/cmd/util/config"
+	"github.com/wish/ctl/pkg/client/types"
+	"os"
+	"strings"
+)
+
+// FindAdhocJob loops through all valid contexts and returns the first active job found
+func (c *Client) FindAdhocJob(appName string, user string) (*types.JobDiscovery, error) {
+
+	// Get all kubernetes contexts from config file
+	config, err := config.GetCtlExt()
+	if err != nil {
+		return nil, err
+	}
+
+	for ctx  := range config {
+
+		if rawruns, ok := config[ctx]["_run"]; ok {
+			runs := make(map[string]types.RunDetails)
+			err := json.Unmarshal([]byte(rawruns), &runs)
+			if err != nil {
+				continue
+			}
+
+			// Check if the app name exists in the raw runs
+			if run, ok := runs[appName]; ok {
+				if run.Active {
+					// Get hostname to use in job name if not supplied
+					if user == "" {
+						user, err = os.Hostname()
+						if err != nil {
+							return nil, errors.New("Unable to get hostname of machine")
+						}
+					}
+
+					// Replace periods with dashes and convert to lower case to follow K8's name constraints
+					user = strings.Replace(user, ".", "-", -1)
+					user = strings.ToLower(user)
+
+					// Extract manifest json as struct to parse
+					var manifestData types.ManifestDetails
+					err = json.Unmarshal([]byte(run.Manifest), &manifestData)
+					if err != nil {
+						return nil, fmt.Errorf("Error parsing manifestJson: %s", err)
+					}
+
+					// Check if a job is already running
+					jobs, err := c.ListJobs(ctx, manifestData.Metadata.Namespace, ListOptions{})
+					if err != nil {
+						return nil, fmt.Errorf("Failed to search for existing job: %s", err)
+					}
+
+					// Return the first job since we limit adhoc pods to one
+					if len(jobs) > 0 {
+						return &jobs[0], nil
+					}
+				}
+			}
+		}
+	}
+	return nil, nil
+}

--- a/pkg/client/findahocpodandpoddetails.go
+++ b/pkg/client/findahocpodandpoddetails.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/wish/ctl/cmd/util/config"
+	"github.com/wish/ctl/pkg/client/types"
+	"strings"
+)
+
+// FindAdhocPodAndAppDetails loops through all valid contexts and returns the first adhoc pod found along with context details about the pod
+func (c *Client) FindAdhocPodAndAppDetails(appName string, user string) (*types.PodDiscovery, *types.ManifestDetails, *types.RunDetails, error) {
+
+	// Get all kubernetes contexts from config file
+	config, err := config.GetCtlExt()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Replace periods with dashes and convert to lower case to follow K8's name constraints
+	user = strings.Replace(user, ".", "-", -1)
+	user = strings.ToLower(user)
+
+	for ctx := range config {
+
+		if rawruns, ok := config[ctx]["_run"]; ok {
+			runs := make(map[string]types.RunDetails)
+			err := json.Unmarshal([]byte(rawruns), &runs)
+			if err != nil {
+				continue
+			}
+
+			// Check if appName is valid
+			if run, ok := runs[appName]; ok {
+				if run.Active {
+
+					// Extract manifest json as struct to parse
+					var manifestData types.ManifestDetails
+					err = json.Unmarshal([]byte(run.Manifest), &manifestData)
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("Error parsing manifestJson: %s", err)
+					}
+
+					// Check if a job is already running
+					pods, err := c.ListPods(ctx, manifestData.Metadata.Namespace, ListOptions{})
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("Failed to search for existing job: %s", err)
+					}
+
+					// Return the first pod since we limit adhoc pods to one
+					if len(pods) > 0 {
+						return &pods[0], &manifestData, &run, nil
+					}
+				}
+			}
+		}
+	}
+	return nil, nil, nil, nil
+}

--- a/pkg/client/types/types.go
+++ b/pkg/client/types/types.go
@@ -72,3 +72,45 @@ type ReplicaSetDiscovery struct {
 func (c ReplicaSetDiscovery) GetLabels() map[string]string {
 	return c.Labels
 }
+
+// RunDetails represents the commands and manifest to apply to launch an adhoc pod
+type RunDetails struct {
+	Resources    resource `json:"resources"`
+	Active       bool     `json:"active"`
+	Manifest     string   `json:"manifest"`
+	PreLogin	 [][]string `json:"pre_login_command,omitempty"`
+	LoginCommand []string `json:"login_command"`
+}
+
+type resource struct {
+	CPU    string `json:"cpu"`
+	Memory string `json:"memory"`
+}
+
+// ManifestDetails represents the manifest details of a running adhoc pod to get attributes like the namespace
+type ManifestDetails struct {
+	Metadata   struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+	APIVersion string `json:"apiVersion"`
+	Kind 	   string `json:"kind"`
+	Spec 	   struct {
+		ActiveDeadlineSeconds string `json:"activeDeadlineSeconds"`
+		Template	template `json:"template"`
+	} `json:"spec"`
+
+}
+
+type template struct {
+	Spec 		struct {
+		Containers    []container `json:"containers"`
+	}  `json:"spec"`
+}
+
+type container struct {
+	Name	string `json:"name"`
+	Command	[]string `json:"command,omitempty"`
+	Args	[]string `json:"args,omitempty"`
+	Image 	string `json:"image"`
+}


### PR DESCRIPTION
Update ctl adhoc job commands to use the namespace provided by the ctl config. Users might not have access to scan all the namespaces which causes these commands to fail without a namespace specification (which the user may or may not know). This will also improve performance of adhoc job commands as it won't need to scan all the namespaces to run the commands.