### PR TITLE
Fix bug where searching for pods would not account for usernames

### DIFF
--- a/cmd/cp.go
+++ b/cmd/cp.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/wish/ctl/cmd/util/parsing"
 	"github.com/wish/ctl/pkg/client"
 	v1 "k8s.io/api/core/v1"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // func cpTest() {
@@ -50,7 +52,14 @@ If no container is set, it will use the first one.`,
 				}
 			}
 
-			pod, _, _, err := c.FindAdhocPodAndAppDetails(appName, user)
+			// Replace periods with dashes and convert to lower case to follow K8's name constraints
+			user = strings.Replace(user, ".", "-", -1)
+			user = strings.ToLower(user)
+			podName := fmt.Sprintf("%s-%s", appName, user)
+			lm, _ := parsing.LabelMatch(fmt.Sprintf("name=%s", podName))
+			options := client.ListOptions{LabelMatch:lm}
+
+			pod, _, _, err := c.FindAdhocPodAndAppDetails(appName, options)
 			if err != nil {
 				return err
 			}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/wish/ctl/cmd/util/parsing"
 	"github.com/wish/ctl/pkg/client"
 	"os"
 	"strings"
@@ -30,9 +31,12 @@ func downCmd(c *client.Client) *cobra.Command {
 			// Replace periods with dashes and convert to lower case to follow K8's name constraints
 			user = strings.Replace(user, ".", "-", -1)
 			user = strings.ToLower(user)
+			podName := fmt.Sprintf("%s-%s", appName, user)
+			lm, _ := parsing.LabelMatch(fmt.Sprintf("name=%s", podName))
+			options := client.ListOptions{LabelMatch:lm}
 
 			// Find existing jobs
-			job, err := c.FindAdhocJob(appName,user)
+			job, err := c.FindAdhocJob(appName,options)
 			if err != nil {
 				return fmt.Errorf("Failed to find jobs: %v", err)
 			}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/wish/ctl/cmd/util/parsing"
 	"github.com/wish/ctl/pkg/client"
 	v1 "k8s.io/api/core/v1"
 	"os"
@@ -47,8 +48,11 @@ If the pod has multiple containers, it will choose the first container found.`,
 			// Replace periods with dashes and convert to lower case to follow K8's name constraints
 			user = strings.Replace(user, ".", "-", -1)
 			user = strings.ToLower(user)
+			podName := fmt.Sprintf("%s-%s", appName, user)
+			lm, _ := parsing.LabelMatch(fmt.Sprintf("name=%s", podName))
+			options := client.ListOptions{LabelMatch:lm}
 
-			pod, manifestData, runDetails, err := c.FindAdhocPodAndAppDetails(appName, user)
+			pod, manifestData, runDetails, err := c.FindAdhocPodAndAppDetails(appName, options)
 			if err != nil {
 				return fmt.Errorf("Failed to find adhoc pod and app details: %v", err)
 			}
@@ -62,7 +66,7 @@ If the pod has multiple containers, it will choose the first container found.`,
 				}
 				time.Sleep(time.Second * 10) // Delay after invoking command to allow clusters to update
 
-				pod, manifestData, runDetails, err = c.FindAdhocPodAndAppDetails(appName,user)
+				pod, manifestData, runDetails, err = c.FindAdhocPodAndAppDetails(appName,options)
 				if err != nil {
 					return err
 				}

--- a/pkg/client/findahocpodandpoddetails.go
+++ b/pkg/client/findahocpodandpoddetails.go
@@ -5,21 +5,16 @@ import (
 	"fmt"
 	"github.com/wish/ctl/cmd/util/config"
 	"github.com/wish/ctl/pkg/client/types"
-	"strings"
 )
 
 // FindAdhocPodAndAppDetails loops through all valid contexts and returns the first adhoc pod found along with context details about the pod
-func (c *Client) FindAdhocPodAndAppDetails(appName string, user string) (*types.PodDiscovery, *types.ManifestDetails, *types.RunDetails, error) {
+func (c *Client) FindAdhocPodAndAppDetails(appName string, options ListOptions) (*types.PodDiscovery, *types.ManifestDetails, *types.RunDetails, error) {
 
 	// Get all kubernetes contexts from config file
 	config, err := config.GetCtlExt()
 	if err != nil {
 		return nil, nil, nil, err
 	}
-
-	// Replace periods with dashes and convert to lower case to follow K8's name constraints
-	user = strings.Replace(user, ".", "-", -1)
-	user = strings.ToLower(user)
 
 	for ctx := range config {
 
@@ -42,7 +37,7 @@ func (c *Client) FindAdhocPodAndAppDetails(appName string, user string) (*types.
 					}
 
 					// Check if a job is already running
-					pods, err := c.ListPods(ctx, manifestData.Metadata.Namespace, ListOptions{})
+					pods, err := c.ListPods(ctx, manifestData.Metadata.Namespace, options)
 					if err != nil {
 						return nil, nil, nil, fmt.Errorf("Failed to search for existing job: %s", err)
 					}


### PR DESCRIPTION
In a previous commit, we pass in the user parameter to the helper function but don't actually use it for searching for the pod. Refactor the code slightly so we can use listoptions instead that are passed in from the commands themselves with the user and appname filter.