### PR TITLE
[ITA-3951 Check CTL versioning by comparing local version and remote tags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,7 @@ func cmd() *cobra.Command {
     if err != nil {
 		fmt.Printf("Unable to retrieve remote CTL tags for version comparison. Error: %s\n",err)
     }
-	if Version != string(out) {
+	if Version != string(out) && err == nil {
 		fmt.Printf(WarningColor, "WARNING: Your CTL is not up-to-date. Please update CTL by running either `brew upgrade wish-ctl` on Mac or `sudo apt-get update && sudo apt-get install ctl` on Linux to get the latest changes and bug fixes\n")
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"os"
-
+	"os/exec"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -17,6 +17,18 @@ func cmd() *cobra.Command {
 	viper.SetDefault("deadline", 18000)
 
 	viper.SetConfigName("config")
+
+	// Check if CTL version is the latest version by comparing local CTL version with remote version tags from GitHub
+	var WarningColor = "\033[1;33m%s\033[0m"
+	out, err := exec.Command("bash", "-c", "git ls-remote --tags https://github.com/wish/ctl.git | tail -n 1 | cut -d'/' -f3 |  cut -d'^' -f1").Output()
+    if err != nil {
+		fmt.Printf("Unable to retrieve remote CTL tags for version comparison. Error: %s\n",err)
+		os.Exit(1)
+    }
+	if Version != string(out) {
+		fmt.Printf(WarningColor, "WARNING: Your CTL is not up-to-date. Please update CTL by running either `brew upgrade wish-ctl` on Mac or `sudo apt-get update && sudo apt-get install ctl` on Linux to get the latest changes and bug fixes\n")
+	}
+
 	var conf string
 	if len(conf) == 0 {
 		if v, ok := os.LookupEnv("XDG_CONFIG_DIR"); ok {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,6 @@ func cmd() *cobra.Command {
 	out, err := exec.Command("bash", "-c", "git ls-remote --tags https://github.com/wish/ctl.git | tail -n 1 | cut -d'/' -f3 |  cut -d'^' -f1").Output()
     if err != nil {
 		fmt.Printf("Unable to retrieve remote CTL tags for version comparison. Error: %s\n",err)
-		os.Exit(1)
     }
 	if Version != string(out) {
 		fmt.Printf(WarningColor, "WARNING: Your CTL is not up-to-date. Please update CTL by running either `brew upgrade wish-ctl` on Mac or `sudo apt-get update && sudo apt-get install ctl` on Linux to get the latest changes and bug fixes\n")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version set default value
-var Version = "v12.0.1-1"
+var Version = "v13.0.9"
 
 func versionCmd(*client.Client) *cobra.Command {
 	return &cobra.Command{


### PR DESCRIPTION
## Issue

Users are not aware of the latest CTL changes and could possibly be on older CTL versions. We want to let the developers know a newer CTL version is available and they should update it on their system. 

In tandem with Home-brew change: [wish/homebrew-wish- Update version tag for CTLand include git as dependency ](https://github.com/wish/homebrew-wish/pull/14/files)
## Fix

To check versions of CTL, we can check the local CTL version (that is stored in the [`Version` variable](https://github.com/wish/ctl/blob/1701b5eaae4df032100346b0ed38f2d4666136d8/cmd/version.go#L9) and returned by `ctl --version`) with the remote tags from Git. The remote tags are used by [Home-brew tap](https://github.com/wish/homebrew-wish/blob/5d750d1a142f387016ab48ae09e78df222972228/Formula/wish-ctl.rb#L4) so the git tags of CTL will reflect the latest Homebrew tap version. 

#### **NOTE:** We will need to ensure the [**`Version` variable in the CTL**](https://github.com/wish/ctl/blob/1701b5eaae4df032100346b0ed38f2d4666136d8/cmd/version.go#L9) application is the latest version tag to maintain consistency  

#### Example of Warning Message
![Screen Shot 2021-03-02 at 10 27 15 AM](https://user-images.githubusercontent.com/77015888/109671188-dd404700-7b41-11eb-8329-5e4fac24ca6d.png)

#### Git Remote Tags command
It returns something like this but I used some shell commands to get the last line and split the string to get the version number only:

``` 
phariharan@phariharan-mac ctl % git ls-remote --tags https://github.com/wish/ctl.git                                             
523bb63710cc6865eba85c424bb1843034e09d13        refs/tags/20200406
72a4f019107535620aa8d4ad6854a11f9929a4be        refs/tags/20200721
599f306cc39ca0641af09a25b9d08ef63b4743a5        refs/tags/v12.0.0
b3039544b691a3e26e892d40218ea7e1775d4426        refs/tags/v12.0.0-1
2b30621be19ddb8d48741dbd1921945b2d2c7b3c        refs/tags/v12.0.0-2
19e05d80b2d0f52f62ce78589c83bf5bd450df4c        refs/tags/v12.0.0-3
f863dc664a0acfe2f2c339ce5bf4815afbdb1351        refs/tags/v12.0.1-1
e7e184d09e09bba62dfbd3dd712835d870be570e        refs/tags/v13.0.0
59ce7cc96fecb00f4535d9b74eaabd731e7e242f        refs/tags/v13.0.0^{}
91da1875840dba169eb49f424db38dbe2c12467a        refs/tags/v13.0.1
1e07941e31f49aaea3f89100f77101fee657d2e4        refs/tags/v13.0.1^{}
bd4b1b5a821f953814a22d643423b3ed3848b3a2        refs/tags/v13.0.2
9e9105cb56dc3e59650eb8e6a70947c7d7945fb6        refs/tags/v13.0.2^{}
a0dd24445eb6fd7d1839eb1dcf3f305af734d916        refs/tags/v13.0.3
46124c772c7975582b83480f0fa48767d6611443        refs/tags/v13.0.3^{}
49cf685dd066292dce7c9ed617e1d1d0d9b73bfb        refs/tags/v13.0.4
b2b45199e0e239387873dd5936d90313675d834c        refs/tags/v13.0.4^{}
1e47ae1a953e2253c195bd27a850b18fa074e07a        refs/tags/v13.0.5
79e6ec9326d175ce99c912b40869d6e929fac9f3        refs/tags/v13.0.6
bdecbab5c7119898eb8e0310d49c45dba5daf26a        refs/tags/v13.0.7
2edb2d62621918784ad85d1e0e4ebe9f01ac48fe        refs/tags/v13.0.8
```
#### Other Suggestions/Ideas

We could also use `brew list` to get local version but the command will be different for Linux (assuming they don't have Linuxbrew/Homebrew installed) so I used `git` to get remote tags. I'll add `git` as a dependency for our Home-brew tap 
```
phariharan@phariharan-mac ctl % brew list --versions wish-ctl
wish-ctl 13.0.8
```

