### PR TITLE
[ITA-4058] Add support for multiple kubeconfigs files

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,8 +53,8 @@ func cmd() *cobra.Command {
 	var c *client.Client
 	if k := viper.GetString("KUBECONFIG"); len(k) > 0 {
 		// split KUBECONFIG string to handle multiple kube config files
-		kube_configs := strings.Split(k, ":")
-		c = client.GetConfigClient(kube_configs)
+		kubeConfigs := strings.Split(k, ":")
+		c = client.GetConfigClient(kubeConfigs)
 	} else {
 		c = client.GetDefaultConfigClient()
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,13 +11,13 @@ import (
 	"github.com/wish/ctl/cmd/cron"
 	"github.com/wish/ctl/cmd/util/config"
 	"github.com/wish/ctl/pkg/client"
+	"strings"
 )
 
 func cmd() *cobra.Command {
 	viper.SetDefault("deadline", 18000)
 
 	viper.SetConfigName("config")
-
 	// Check if CTL version is the latest version by comparing local CTL version with remote version tags from GitHub
 	var WarningColor = "\033[1;33m%s\033[0m"
 	out, err := exec.Command("bash", "-c", "git ls-remote --tags https://github.com/wish/ctl.git | tail -n 1 | cut -d'/' -f3 |  cut -d'^' -f1 | tr -d '\n'").Output()
@@ -51,9 +51,10 @@ func cmd() *cobra.Command {
 	}
 
 	var c *client.Client
-	if k := viper.GetString("kubeconfig"); len(k) > 0 {
-		c = client.GetConfigClient(k)
-		// konf = true
+	if k := viper.GetString("KUBECONFIG"); len(k) > 0 {
+		// split KUBECONFIG string to handle multiple kube config files
+		kube_configs := strings.Split(k, ":")
+		c = client.GetConfigClient(kube_configs)
 	} else {
 		c = client.GetDefaultConfigClient()
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version set default value
-var Version = "v14.0.0"
+var Version = "v14.1.0"
 
 func versionCmd(*client.Client) *cobra.Command {
 	return &cobra.Command{

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -47,12 +47,16 @@ func GetDefaultConfigClient() *Client {
 }
 
 // GetConfigClient returns a client with a specific kubeconfig path
-func GetConfigClient(path string) *Client {
-	contexts := helper.GetContexts(path)
+func GetConfigClient(paths []string) *Client {
+	var contexts []string
+	for _, path := range paths {
+		context := helper.GetContexts(path)
+		contexts = append(contexts, context...)
+	}
 	return &Client{
 		clientsetGetter: &configClientsetGetter{
 			clientsets: make(map[string]clusterFunctionality),
-			config:     path,
+			config:     paths,
 		},
 		contextsGetter: StaticContextsGetter{
 			contexts: contexts,

--- a/pkg/client/execinpod.go
+++ b/pkg/client/execinpod.go
@@ -45,7 +45,7 @@ func (c *Client) ExecInPod(contexts []string, namespace, name, container string,
 	}, scheme.ParameterCodec)
 
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: helper.GetKubeConfigPath()},
+		&clientcmd.ClientConfigLoadingRules{Precedence: helper.GetKubeConfigPath()},
 		&clientcmd.ConfigOverrides{CurrentContext: pod.Context}).ClientConfig()
 
 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())

--- a/pkg/client/helper/helper.go
+++ b/pkg/client/helper/helper.go
@@ -3,22 +3,23 @@ package helper
 import (
 	"os"
 	"path/filepath"
-
 	"k8s.io/client-go/tools/clientcmd"
+	"strings"
 )
 
 // GetKubeConfigPath returns the default location of a kubeconfig file
-func GetKubeConfigPath() string {
-	// TODO: handle multiple paths in KUBECONFIG
+func GetKubeConfigPath() []string {
 	if fl := os.Getenv("KUBECONFIG"); fl != "" {
-		return fl
+		// split KUBECONFIG string to handle multiple kube config files
+		kube_configs := strings.Split(fl, ":")
+		return kube_configs
 	}
 	home, err := os.UserHomeDir()
 	if err != nil { // Can't find home dir
 		panic(err.Error())
 	}
 
-	return filepath.Join(home, ".kube", "config")
+	return []string {filepath.Join(home, ".kube", "/Users/phariharan/.kube/config")}
 }
 
 // GetContexts returns a list of clusters from a config file

--- a/pkg/client/helper/helper.go
+++ b/pkg/client/helper/helper.go
@@ -11,8 +11,8 @@ import (
 func GetKubeConfigPath() []string {
 	if fl := os.Getenv("KUBECONFIG"); fl != "" {
 		// split KUBECONFIG string to handle multiple kube config files
-		kube_configs := strings.Split(fl, ":")
-		return kube_configs
+		kubeConfigs := strings.Split(fl, ":")
+		return kubeConfigs
 	}
 	home, err := os.UserHomeDir()
 	if err != nil { // Can't find home dir

--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -23,7 +23,7 @@ type clusterFunctionality struct {
 
 type configClientsetGetter struct {
 	clientsets map[string]clusterFunctionality
-	config     string
+	config     []string
 	cslock     sync.RWMutex
 }
 
@@ -36,7 +36,7 @@ func (d *configClientsetGetter) getContextInterface(context string) (kubernetes.
 	d.cslock.RUnlock()
 	// Get config
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: d.config},
+		&clientcmd.ClientConfigLoadingRules{Precedence: d.config},
 		&clientcmd.ConfigOverrides{CurrentContext: context}).ClientConfig()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Issue
Users may have multiple kube configs but currently `CTL` does not support multiple kubeconfigs. Multiple kubceonfigs will be of the following format - 
```
export KUBECONFIG=$KUBECONFIG:config-demo:config-demo-2
```

> The KUBECONFIG environment variable is a list of paths to configuration files. The list is colon-delimited for Linux and Mac, and semicolon-delimited for Windows.

## Fix
Instead of specifying a specific path using `ExplicitPath` to the [`ClientConfigLoadingRules` Kubernetes/go API](https://github.com/kubernetes/client-go/blob/f6ce18ae578c8cca64d14ab9687824d9e1305a67/tools/clientcmd/loader.go#L113), we can pass a list of strings using `Precedence` (split by `:`). 

### Notes
As the name suggests, the order of this string matters for prioritizing contexts that overlap between config files. The left most config file in the `KUBECONFIG` environment variable that sets a particular map key wins (context mapping). Conflicting entries from the other files (to the right) are discarded.

```
export KUBECONFIG=HIGHEST-PRIO:LOWER-PRIO:LOWEST-PRIO
```

