### PR TITLE
Don't login to pods that are in the middle of termination

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -129,7 +129,7 @@ If the pod has multiple containers, it will choose the first container found.`,
 					command.Stdin = os.Stdin
 					err =  command.Run()
 					if err != nil {
-						return fmt.Errorf("Failed to run pre-login commands: %v", err)
+						fmt.Errorf("Failed to run pre-login commands: %v", err)
 					}
 				}
 			}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -129,7 +129,7 @@ If the pod has multiple containers, it will choose the first container found.`,
 					command.Stdin = os.Stdin
 					err =  command.Run()
 					if err != nil {
-						fmt.Errorf("Failed to run pre-login commands: %v", err)
+						return fmt.Errorf("Failed to run pre-login commands: %v", err)
 					}
 				}
 			}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -139,6 +139,7 @@ func upCmd(c *client.Client) *cobra.Command {
 							// Check if a job is already running. We want to limit 1 job per user.
 							// Get the namespace for the job from the manifest
 							// We find the job using its name '<app name>-<host name>' eg 'foo-bar'
+							fmt.Printf("Looking for Jobs.....\n")
 							jobs, err := c.FindJobs([]string{}, manifestData.Metadata.Namespace, []string{fmt.Sprintf("%s-%s", appName, user)},
 								client.ListOptions{},
 							)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version set default value
-var Version = "v14.3.0"
+var Version = "v14.4.0"
 
 func versionCmd(*client.Client) *cobra.Command {
 	return &cobra.Command{


### PR DESCRIPTION
Bypass pre-login script failures by displaying warning error of script failing, but still allow pod login to proceed. and update tag version