### PR TITLE
bypass prelogin failures

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -112,7 +112,7 @@ If the pod has multiple containers, it will choose the first container found.`,
 					command.Stdin = os.Stdin
 					err =  command.Run()
 					if err != nil {
-						return fmt.Errorf("Failed to run pre-login commands: %v", err)
+						fmt.Errorf("Failed to run pre-login commands: %v", err)
 					}
 				}
 			}


### PR DESCRIPTION
Remove return statement from erroring out during pre-login script
s3 Access is part of pre-login script, users should still be allowed to use ctl without s3 access
https://jira.wish.site/browse/ITA-3932